### PR TITLE
Fix screen title

### DIFF
--- a/SDKv5_Examples/PlaygroundSamples/app/src/main/java/ca/mappedin/playgroundsamples/examples/AddInteractivity.kt
+++ b/SDKv5_Examples/PlaygroundSamples/app/src/main/java/ca/mappedin/playgroundsamples/examples/AddInteractivity.kt
@@ -15,7 +15,7 @@ class AddInteractivity : AppCompatActivity(), MPIMapViewListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_example)
-        this.title = "Markers"
+        this.title = "Add Interactivity"
 
         mapView = findViewById<MPIMapView>(R.id.mapView)
         // See Trial API key Terms and Conditions


### PR DESCRIPTION
The Add Interactivity activity was incorrectly titled Markers.